### PR TITLE
Fix bug in lvm hook with lvm_discard unset

### DIFF
--- a/hooks/lvm/lvm.init
+++ b/hooks/lvm/lvm.init
@@ -13,7 +13,7 @@ export DM_DISABLE_UDEV=1
 mkdir -p /run/lvm /run/lock/lvm
 
 set -- \
-    --sysinit -qq -aay "${lvm_discard:+--config=devices{issue_discards=1}}"
+    --sysinit -qq -aay "${lvm_discard:+--config=devices\{issue_discards=1\}}"
 
 if [ "$lvm_group" ] && [ "$lvm_name" ]; then
     lvm lvchange $@ "${lvm_group}/${lvm_name}"


### PR DESCRIPTION
```sh
$ unset lvm_discard
$ echo "${lvm_discard:+--config=devices{issue_discards=1}}"
}
$ echo "${lvm_discard:+--config=devices\{issue_discards=1\}}"

$ lvm_discard=1
$ echo "${lvm_discard:+--config=devices\{issue_discards=1\}}"
--config=devices{issue_discards=1}
```

You need to escape the braces or else when `lvm_discard` is unset the result is `}`.
I was getting an error on boot that the volume group `}` was invalid due to this.