### PR TITLE
Resume Hook (Hibernation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tiny initramfs written in POSIX shell
 - ZFS + native encryption support
 - LUKS (detached header, key), LVM
 - mdev, mdevd, eudev, systemd-udevd
+- Resume from swap partition
 
 ## Dependencies
 

--- a/doc/tinyramfs.5
+++ b/doc/tinyramfs.5
@@ -144,6 +144,14 @@ lvm_tag
 The tag of your LVM logical volume.\&
 .P
 .RE
+.SS RESUME
+.P
+resume
+.P
+.RS 4
+The location of your swap partition.\&
+.P
+.RE
 .SS ZFS
 .P
 zfs_key

--- a/doc/tinyramfs.5.scd
+++ b/doc/tinyramfs.5.scd
@@ -103,6 +103,12 @@ lvm_tag
 
 	The tag of your LVM logical volume.
 
+## RESUME
+
+resume
+
+	The location of your swap partition.
+
 ## ZFS
 
 zfs_key

--- a/hook/resume/resume
+++ b/hook/resume/resume
@@ -1,0 +1,7 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+#
+# https://shellcheck.net/wiki/SC2154
+# shellcheck disable=2154
+
+copy_exec stat

--- a/hook/resume/resume
+++ b/hook/resume/resume
@@ -4,4 +4,5 @@
 # https://shellcheck.net/wiki/SC2154
 # shellcheck disable=2154
 
-copy_exec stat
+copy_exec readlink
+copy_exec cat

--- a/hook/resume/resume.init
+++ b/hook/resume/resume.init
@@ -1,0 +1,12 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+#
+# https://shellcheck.net/wiki/SC2154
+# shellcheck disable=2154
+
+resolve_device "$resume"
+
+if [ -n "$device" ]; then
+	printf '%u:%u\n' $(stat -L -c '0x%t 0x%T' "$device") > /sys/power/resume || \
+	panic "failed to resume"
+fi

--- a/hook/resume/resume.init
+++ b/hook/resume/resume.init
@@ -9,6 +9,6 @@ resolve_device "$resume"
 if [ -n "$device" ]; then
 	dev_link=$(readlink "$device")
 
-	cat /sys/class/block/${dev_link##*/}/dev > /sys/power/resume || \
+	cat /sys/class/block/"${dev_link##*/}"/dev > /sys/power/resume || \
 	panic "failed to resume"
 fi

--- a/hook/resume/resume.init
+++ b/hook/resume/resume.init
@@ -7,6 +7,8 @@
 resolve_device "$resume"
 
 if [ -n "$device" ]; then
-	printf '%u:%u\n' $(stat -L -c '0x%t 0x%T' "$device") > /sys/power/resume || \
+	dev_link=$(readlink "$device")
+
+	cat /sys/class/block/${dev_link##*/}/dev > /sys/power/resume || \
 	panic "failed to resume"
 fi


### PR DESCRIPTION
- Added resume hook
- Also added resume to docs and readme
- Not for swap files, only for swap partitions

Uses resolve_device for the `resume` variable in config. Then uses printf and stat to get major:minor numbers of the partition and puts that into /sys/power/resume.
Works with my luks/lvm kiss linux with swap partition under luks/lvm (resumes after luks password is entered). Should work for any other swap setup (except swap files).